### PR TITLE
Replacing functions deprecated in Qt5

### DIFF
--- a/simplecrypt.cpp
+++ b/simplecrypt.cpp
@@ -30,6 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QtGlobal>
 #include <QDateTime>
 #include <QCryptographicHash>
+#include <QDataStream>
 
 SimpleCrypt::SimpleCrypt():
     m_key(0),
@@ -139,20 +140,20 @@ QString SimpleCrypt::encryptToString(const QString& plaintext)
 {
     QByteArray plaintextArray = plaintext.toUtf8();
     QByteArray cypher = encryptToByteArray(plaintextArray);
-    QString cypherString = QString::fromAscii(cypher.toBase64());
+    QString cypherString = QString::fromLatin1(cypher.toBase64());
     return cypherString;
 }
 
 QString SimpleCrypt::encryptToString(QByteArray plaintext)
 {
     QByteArray cypher = encryptToByteArray(plaintext);
-    QString cypherString = QString::fromAscii(cypher.toBase64());
+    QString cypherString = QString::fromLatin1(cypher.toBase64());
     return cypherString;
 }
 
 QString SimpleCrypt::decryptToString(const QString &cyphertext)
 {
-    QByteArray cyphertextArray = QByteArray::fromBase64(cyphertext.toAscii());
+    QByteArray cyphertextArray = QByteArray::fromBase64(cyphertext.toLatin1());
     QByteArray plaintextArray = decryptToByteArray(cyphertextArray);
     QString plaintext = QString::fromUtf8(plaintextArray, plaintextArray.size());
 
@@ -169,7 +170,7 @@ QString SimpleCrypt::decryptToString(QByteArray cypher)
 
 QByteArray SimpleCrypt::decryptToByteArray(const QString& cyphertext)
 {
-    QByteArray cyphertextArray = QByteArray::fromBase64(cyphertext.toAscii());
+    QByteArray cyphertextArray = QByteArray::fromBase64(cyphertext.toLatin1());
     QByteArray ba = decryptToByteArray(cyphertextArray);
 
     return ba;
@@ -184,6 +185,9 @@ QByteArray SimpleCrypt::decryptToByteArray(QByteArray cypher)
     }
 
     QByteArray ba = cypher;
+	
+    if( cypher.count() < 3 )
+        return QByteArray();
 
     char version = ba.at(0);
 


### PR DESCRIPTION
This commit replaces deprecated toAscii() and fromAscii() with
toLatin1() and fromLatin1()
